### PR TITLE
disable all HTML emails

### DIFF
--- a/authentication/admin.py
+++ b/authentication/admin.py
@@ -171,14 +171,20 @@ class UpcommingsUserAdmin(admin.ModelAdmin):
                     + "</strong>.",
                     "date": datetime.datetime.now().strftime("%d.%m.%Y"),
                 },
-            )  #!Hier habe ich ein wenig gefuscht
+            )  #!Hier habe ich ein wenig gefuscht; dies wird gerade nicht genutzt!
 
+            # async_send_mail.delay(
+            #     email_subject,
+            #     email_str_body,
+            #     up_user.student.child_email,
+            #     email_html_body=email_html_body,
+            # )
+            
             async_send_mail.delay(
                 email_subject,
                 email_str_body,
                 up_user.student.child_email,
-                email_html_body=email_html_body,
-            )
+            ) #! Hier wird keine HTML versandt
 
             up_user.email_send = True
             up_user.save()
@@ -234,14 +240,20 @@ class UpcommingsUserAdmin(admin.ModelAdmin):
                     + up_user.otp
                     + "</strong>.",
                 },
-            )  #!Hier habe ich ein wenig gefuscht
+            )  #!Hier habe ich ein wenig gefuscht; wird nicht genutzt!
 
+            # async_send_mail.delay(
+            #     email_subject,
+            #     email_str_body,
+            #     new_up_user.student.child_email,
+            #     email_html_body=email_html_body,
+            # ) 
+            
             async_send_mail.delay(
                 email_subject,
                 email_str_body,
                 new_up_user.student.child_email,
-                email_html_body=email_html_body,
-            )
+            ) #! Hier wird keine HTML versandt
 
             new_up_user.email_send = True
             new_up_user.save()

--- a/authentication/utils.py
+++ b/authentication/utils.py
@@ -49,14 +49,20 @@ def register_new_teacher(email: str):
                 "token": teacher_registration_token.make_token(new_teacher),
                 "date": datetime.datetime.now().strftime("%d.%m.%Y"),
             },
-        )
+        ) #! Dies wird gerade nicht benutzt!
 
+        # async_send_mail.delay(
+        #     email_subject,
+        #     email_str_body,
+        #     new_teacher.email,
+        #     email_html_body=email_html_body,
+        # )
+        
         async_send_mail.delay(
             email_subject,
             email_str_body,
             new_teacher.email,
-            email_html_body=email_html_body,
-        )
+        ) #! Hier wird keine HTML versandt
     else:
         raise "Nutzer existiert bereits"
 
@@ -108,11 +114,17 @@ def send_parent_registration_mail(up_user: Upcomming_User):
                     "url": str(os.environ.get("PUBLIC_URL")) + reverse("parent_create_account", kwargs={"user_token": up_user.user_token, "key_token": up_user.access_key, "token": parent_registration_token.make_token(up_user)}),
                     "date": datetime.datetime.now().strftime("%d.%m.%Y"),
                 },
-            )
+            ) #! Dies wird derzeit nicht benutzt
 
+            # async_send_mail.delay(
+            #     email_subject,
+            #     email_str_body,
+            #     up_user.parent_email,
+            #     email_html_body=email_html_body,
+            # )
+            
             async_send_mail.delay(
                 email_subject,
                 email_str_body,
                 up_user.parent_email,
-                email_html_body=email_html_body,
-            )
+            ) #! Hier wird keine HTML versendet!

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -555,7 +555,16 @@ def password_reset_request(request):
                         "authentication/email/password_reset/password_reset_email.txt",
                         {
                             "user": user,
-                            "url": str(os.environ.get("PUBLIC_URL")) + reverse("password_reset_confirm", kwargs={"uidb64": urlsafe_base64_encode(force_bytes(user.pk)), "token": default_token_generator.make_token(user)}),
+                            "url": str(os.environ.get("PUBLIC_URL"))
+                            + reverse(
+                                "password_reset_confirm",
+                                kwargs={
+                                    "uidb64": urlsafe_base64_encode(
+                                        force_bytes(user.pk)
+                                    ),
+                                    "token": default_token_generator.make_token(user),
+                                },
+                            ),
                         },
                     )
                     email_html_body = render_to_string(
@@ -567,14 +576,20 @@ def password_reset_request(request):
                             "token": default_token_generator.make_token(user),
                             "date": datetime.datetime.now().strftime("%d.%m.%Y"),
                         },
-                    )
+                    )  #! Dies wird derzeit nicht benutzt
+
+                    # async_send_mail.delay(
+                    #     email_subject,
+                    #     email_str_body,
+                    #     user.email,
+                    #     email_html_body=email_html_body,
+                    # )
 
                     async_send_mail.delay(
                         email_subject,
                         email_str_body,
                         user.email,
-                        email_html_body=email_html_body,
-                    )
+                    )  #! Hier wird keine HTML versendet!
             return redirect("password_reset_done")
     password_reset_form = CustomPasswordResetForm()
     return render(
@@ -629,7 +644,11 @@ class TeacherRegistrationView(View):
                     "Ihr Lehreraccount wurde nun erfolgreich erstellt. Sie können sich nun anmelden.",
                 )
                 return redirect("login")
-            payload = {"user": user, "form": form, "validators": password_validators_help_text_html}
+            payload = {
+                "user": user,
+                "form": form,
+                "validators": password_validators_help_text_html,
+            }
             return render(
                 request,
                 "authentication/register_teacher/register_teacher_create_account.html",

--- a/dashboard/signals.py
+++ b/dashboard/signals.py
@@ -82,14 +82,20 @@ def addAnnouncements(sender, instance: Inquiry, **kwargs):
                     #    ]
                     #),
                 },
-            )
+            ) #! Dies wird derzeit nicht benutzt
 
+            # async_send_mail.delay(
+            #     email_subject,
+            #     email_str_body,
+            #     instance.respondent.email,
+            #     email_html_body=email_html_body,
+            # )
+            
             async_send_mail.delay(
                 email_subject,
                 email_str_body,
                 instance.respondent.email,
-                email_html_body=email_html_body,
-            )
+            ) #! Hier wird keine HTML versendet
 
             Announcements.objects.create(
                 user=instance.respondent,
@@ -142,14 +148,20 @@ def addAnnouncements(sender, instance: Inquiry, **kwargs):
                     #    ]
                     #),
                 },
-            )
+            ) #! Dies wird derzeit nicht benutzt
 
+            # async_send_mail.delay(
+            #     email_subject,
+            #     email_str_body,
+            #     instance.respondent.email,
+            #     email_html_body=email_html_body,
+            # )
+            
             async_send_mail.delay(
                 email_subject,
                 email_str_body,
                 instance.respondent.email,
-                email_html_body=email_html_body,
-            )
+            )#! Hier wird keine HTML versendet
 
             Announcements.objects.create(
                 user=instance.respondent,


### PR DESCRIPTION
To get the system working as fast as possible, we had to disable all HTML emails. Now emails are only available as regular text. 